### PR TITLE
:sparkles: add tagline and divider to MucIntro

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import "../public/assets/temporary/muenchende-style.css";
+import "../public/assets/temporary/custom-style.css";
 import "../public/assets/temporary/muenchende-fontfaces.css";
 
 /** @type { import('@storybook/vue3').Preview } */

--- a/docs/GettingStarted.mdx
+++ b/docs/GettingStarted.mdx
@@ -54,6 +54,7 @@ In your Webcomponents root you should import the MDE5-CSS and SVG-Sprite for MDE
 
 <style>
   @import "@muenchen/muc-patternlab-vue/dist/assets/temporary/muenchende-style.css";
+  @import "@muenchen/muc-patternlab-vue/dist/assets/temporary/custom-style.css";
 </style>
 ```
 

--- a/public/assets/temporary/custom-style.css
+++ b/public/assets/temporary/custom-style.css
@@ -1,0 +1,19 @@
+/**
+ * We need this css to ensure the correct patternlab
+ * behaviour inside of a webcomponent.
+ */
+:root {
+    --color-brand-main-blue: #005A9F;
+    --color-neutrals-blue: #BDD4EA;
+    --color-neutrals-blue-xlight: #F2F6FA;
+    --color-neutrals-grey: #3A5368;
+    color: var(--color-neutrals-grey);
+    font-family: Open Sans, Arial, sans-serif;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.5;
+    word-break: break-word;
+    background-color: #fff;
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}

--- a/src/components/Intro/MucIntro.stories.ts
+++ b/src/components/Intro/MucIntro.stories.ts
@@ -20,9 +20,18 @@ Used e.g. in https://stadt.muenchen.de/buergerservice/anliegen.html.
 
 export const Default = {
   args: {
-    title: "Intro-Title",
+    tagline: "Tagline",
+    title: "Intro with Title",
+    divider: true,
     default:
       "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.\n" +
       "    Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.",
+  },
+};
+
+export const Minimal = {
+  args: {
+    title: "Smaller Intro with Title",
+    default: Default.args.default,
   },
 };

--- a/src/components/Intro/MucIntro.vue
+++ b/src/components/Intro/MucIntro.vue
@@ -4,6 +4,14 @@ defineProps<{
    * Title of the Intro
    */
   title: string;
+  /**
+   * Tagline of the Intro (above the title)
+   */
+  tagline: string;
+  /**
+   * Toggle to show a divider between title and body
+   */
+  divider: boolean;
 }>();
 
 defineSlots<{
@@ -15,18 +23,40 @@ defineSlots<{
 </script>
 
 <template>
-  <div class="m-intro m-intro-summary-text">
-    <div class="container">
-      <div class="m-intro-summary-text__body">
-        <div class="m-intro-summary-text__grid">
-          <div class="m-intro-summary-text__content">
-            <h1 class="m-intro-summary-text__title">{{ title }}</h1>
-            <p>
-              <slot></slot>
-            </p>
+
+  <div class="m-intro m-intro-vertical">
+    <div class="m-intro-vertical__body">
+      <div class="container">
+        <div class="m-intro-vertical__grid">
+          <div class="m-intro-vertical__grid-inner">
+            <span v-if="tagline" class="m-intro-vertical__tagline">
+              {{ tagline }}
+            </span>
+
+            <h1 class="m-intro-vertical__title">
+              {{ title }}
+            </h1>
+
+            <div v-if="divider" class="ticket-divider"></div>
+
+            <div class="m-intro-vertical__content">
+              <p>
+                <slot></slot>
+              </p>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.ticket-divider {
+  align-self: stretch;
+  height: 0;
+  border: 1px var(--color-neutrals-blue) solid;
+  margin-top: 8px;
+  margin-bottom: 16px;
+}
+</style>


### PR DESCRIPTION
Now also using the correct CSS classes for a vertical article and not a summary article.

Before:

![image](https://github.com/it-at-m/muc-patternlab-vue/assets/10800158/c77abc6c-d7b8-43ac-a6ef-1892c763bbe6)

After:

![image](https://github.com/it-at-m/muc-patternlab-vue/assets/10800158/3efac8fc-fb5b-497d-a4de-eddf1599314f)
