### PR TITLE
280 file upload change requests

### DIFF
--- a/src/components/FileDropzone/MucFileDropzone.vue
+++ b/src/components/FileDropzone/MucFileDropzone.vue
@@ -237,7 +237,7 @@ const _isTotalFilesSumValid = (files: File[]) => {
   width: 100%;
   height: 100%;
   position: relative;
-  border: 2px dashed #337bb2;
+  border: 1px dashed #337bb2;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/FileDropzone/MucFileDropzone.vue
+++ b/src/components/FileDropzone/MucFileDropzone.vue
@@ -36,9 +36,7 @@
     v-if="!validTotalFileSizes && maxTotalFileSizeWarning"
     class="m-error-message drop-zone-error-message"
   >
-    <MucIcon
-      icon="warning--filled"
-    />
+    <MucIcon icon="warning--filled" />
     <span>
       {{ maxTotalFileSizeWarning }}
     </span>
@@ -47,9 +45,7 @@
     v-if="!validFilesAmount"
     class="m-error-message drop-zone-error-message"
   >
-    <MucIcon
-      icon="warning--filled"
-    />
+    <MucIcon icon="warning--filled" />
     <span>
       {{ invalidAmountWarning }}
     </span>

--- a/src/components/FileDropzone/MucFileDropzone.vue
+++ b/src/components/FileDropzone/MucFileDropzone.vue
@@ -24,14 +24,14 @@
     v-if="!validFileSizes && maxFileSizeWarning"
     class="m-error-message"
   >
-    <MucIcon icon="warning" />
+    <MucIcon icon="warning--filled" />
     {{ maxFileSizeWarning }}
   </span>
   <span
     v-if="!validTotalFileSizes && maxTotalFileSizeWarning"
     class="m-error-message"
   >
-    <MucIcon icon="warning" />
+    <MucIcon icon="warning--filled" />
     {{ maxTotalFileSizeWarning }}
   </span>
   <span

--- a/src/components/FileDropzone/MucFileDropzone.vue
+++ b/src/components/FileDropzone/MucFileDropzone.vue
@@ -22,24 +22,37 @@
   </div>
   <span
     v-if="!validFileSizes && maxFileSizeWarning"
-    class="m-error-message"
+    class="m-error-message drop-zone-error-message"
   >
-    <MucIcon icon="warning--filled" />
-    {{ maxFileSizeWarning }}
+    <MucIcon
+      icon="warning--filled"
+      class="icon"
+    />
+    <span>
+      {{ maxFileSizeWarning }}
+    </span>
   </span>
   <span
     v-if="!validTotalFileSizes && maxTotalFileSizeWarning"
-    class="m-error-message"
+    class="m-error-message drop-zone-error-message"
   >
-    <MucIcon icon="warning--filled" />
-    {{ maxTotalFileSizeWarning }}
+    <MucIcon
+      icon="warning--filled"
+    />
+    <span>
+      {{ maxTotalFileSizeWarning }}
+    </span>
   </span>
   <span
     v-if="!validFilesAmount"
-    class="m-error-message"
+    class="m-error-message drop-zone-error-message"
   >
-    <MucIcon icon="warning" />
-    {{ invalidAmountWarning }}
+    <MucIcon
+      icon="warning--filled"
+    />
+    <span>
+      {{ invalidAmountWarning }}
+    </span>
   </span>
 </template>
 
@@ -253,5 +266,18 @@ const _isTotalFilesSumValid = (files: File[]) => {
 
 .drop-zone.is-not-disabled {
   cursor: pointer;
+}
+
+.drop-zone-error-message {
+  display: flex;
+  align-items: flex-start;
+}
+
+.drop-zone-error-message .icon {
+  margin-top: 0;
+}
+
+.drop-zone-error-message span {
+  margin-left: 4px;
 }
 </style>


### PR DESCRIPTION
**Description**

Change requests after review.
- The border of the upload box should have a thickness of 1px instead of 2px, like the input field.
- Error text wrapping: If an error text spans two lines, the second line should start to the right of the info icon.
- The icon before the error text should be the filled version of the info icon, not the outline version.


**Reference**

Issues #280
