### PR TITLE
:sparkles: 369 show icons on the left side of the button

### DIFF
--- a/src/components/Button/MucButton.stories.ts
+++ b/src/components/Button/MucButton.stories.ts
@@ -60,3 +60,11 @@ export const IconAnimated = {
     iconAnimated: true,
   },
 };
+
+export const IconShownLeft = {
+  args: {
+    default: "With Icon",
+    icon: "arrow-left",
+    iconShownLeft: true,
+  },
+};

--- a/src/components/Button/MucButton.vue
+++ b/src/components/Button/MucButton.vue
@@ -6,19 +6,14 @@
     :class="[buttonVariantClass, iconAnimatedClass, disabledClass]"
   >
     <span>
+      <slot v-if="!iconShownLeft" />
       <muc-icon
-        v-if="icon && iconShownLeft"
-        :icon="icon"
-        class="m-button__icon set-right-margin"
-        :class="{ 'no-left-margin': !iconAnimated }"
-      />
-      <slot />
-      <muc-icon
-        v-if="icon && !iconShownLeft"
+        v-if="icon"
         :icon="icon"
         class="m-button__icon"
-        :class="{ 'no-left-margin': !slots.default }"
+        :class="iconPositionClass"
       />
+      <slot v-if="iconShownLeft" />
     </span>
   </button>
 </template>
@@ -101,6 +96,11 @@ const iconAnimatedClass = computed(() => {
     return "";
   }
 });
+
+const iconPositionClass = computed(() => ({
+  "set-right-margin": iconShownLeft,
+  "no-left-margin": !iconShownLeft ? !slots.default : !iconAnimated,
+}));
 
 /**
  * Emit a click event if not in disabled state.

--- a/src/components/Button/MucButton.vue
+++ b/src/components/Button/MucButton.vue
@@ -6,9 +6,15 @@
     :class="[buttonVariantClass, iconAnimatedClass, disabledClass]"
   >
     <span>
+      <muc-icon
+          v-if="icon && iconShownLeft"
+          :icon="icon"
+          class="m-button__icon set-right-margin"
+          :class="{ 'no-left-margin': !iconAnimated }"
+      />
       <slot />
       <muc-icon
-        v-if="icon"
+        v-if="icon && !iconShownLeft"
         :icon="icon"
         class="m-button__icon"
         :class="{ 'no-left-margin': !slots.default }"
@@ -30,6 +36,7 @@ const {
   variant = "primary",
   disabled = false,
   iconAnimated = false,
+  iconShownLeft = false,
 } = defineProps<{
   /**
    * The variant prop gives you easy access to several different button styles.
@@ -51,6 +58,12 @@ const {
    * Default is `false`
    */
   iconAnimated?: boolean;
+  /**
+   * Whether the Icon should be shown on the left side of the button (slide-right) or not.
+   *
+   * Default is `false`
+   */
+  iconShownLeft?: boolean;
 }>();
 
 defineSlots<{
@@ -79,9 +92,15 @@ const buttonVariantClass = computed(() => {
   }
 });
 
-const iconAnimatedClass = computed(() =>
-  iconAnimated ? "m-button--animated-right" : ""
-);
+const iconAnimatedClass = computed(() => {
+      if (iconAnimated && iconShownLeft) {
+        return "m-button--animated-left";
+      } else if (iconAnimated) {
+        return "m-button--animated-right";
+      } else {
+        return "";
+      }
+});
 
 /**
  * Emit a click event if not in disabled state.
@@ -99,6 +118,10 @@ const disabledClass = computed(() => (disabled ? "disabled" : ""));
 <style scoped>
 .no-left-margin {
   margin-left: 0;
+}
+
+.set-right-margin {
+  margin-right: 0.75rem;
 }
 
 [aria-disabled="true"] {

--- a/src/components/Button/MucButton.vue
+++ b/src/components/Button/MucButton.vue
@@ -7,10 +7,10 @@
   >
     <span>
       <muc-icon
-          v-if="icon && iconShownLeft"
-          :icon="icon"
-          class="m-button__icon set-right-margin"
-          :class="{ 'no-left-margin': !iconAnimated }"
+        v-if="icon && iconShownLeft"
+        :icon="icon"
+        class="m-button__icon set-right-margin"
+        :class="{ 'no-left-margin': !iconAnimated }"
       />
       <slot />
       <muc-icon
@@ -93,13 +93,13 @@ const buttonVariantClass = computed(() => {
 });
 
 const iconAnimatedClass = computed(() => {
-      if (iconAnimated && iconShownLeft) {
-        return "m-button--animated-left";
-      } else if (iconAnimated) {
-        return "m-button--animated-right";
-      } else {
-        return "";
-      }
+  if (iconAnimated && iconShownLeft) {
+    return "m-button--animated-left";
+  } else if (iconAnimated) {
+    return "m-button--animated-right";
+  } else {
+    return "";
+  }
 });
 
 /**


### PR DESCRIPTION
**Description**

Add functionality to show icons on the left side of the button.

**Reference**

Issues #369


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button component with option to display icon on the left side
	- Added configurable icon positioning for buttons

- **Style**
	- Introduced new margin class for left-side icon spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->