### PR TITLE
:wrench: New release note template for semantic-release

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,5 +12,5 @@ module.exports = {
   parserOptions: {
     ecmaVersion: "latest",
   },
-  ignorePatterns: ["/storybook-static", "/dist"], // Ignoriere die Ordner foo und bar
+  ignorePatterns: ["/storybook-static", "/dist", "/build"], // Ignoriere die Ordner foo und bar
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 dist
 public
 storybook-static
+build
 
 # Files
 package.json

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,9 +1,9 @@
 const { promisify } = require("util");
 const dateFormat = require("dateformat");
-const { join } = require("node:path");
+const { join, resolve} = require("node:path");
 const readFileAsync = promisify(require("fs").readFile);
 
-const releaseNotesTemplatePath = path.resolve(
+const releaseNotesTemplatePath = resolve(
   __dirname,
   "build/release-notes.hbs"
 );

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,12 +1,9 @@
 const { promisify } = require("util");
 const dateFormat = require("dateformat");
-const { join, resolve} = require("node:path");
+const { join, resolve } = require("node:path");
 const readFileAsync = promisify(require("fs").readFile);
 
-const releaseNotesTemplatePath = resolve(
-  __dirname,
-  "build/release-notes.hbs"
-);
+const releaseNotesTemplatePath = resolve(__dirname, "build/release-notes.hbs");
 const commitTemplateDir =
   "node_modules/semantic-release-gitmoji/lib/assets/templates";
 

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -3,11 +3,11 @@ const dateFormat = require("dateformat");
 const { join } = require("node:path");
 const readFileAsync = promisify(require("fs").readFile);
 
-const TEMPLATE_DIR =
-  "node_modules/semantic-release-gitmoji/lib/assets/templates";
-// the *.hbs template and partials should be passed as strings of contents
-const template = readFileAsync(join(TEMPLATE_DIR, "default-template.hbs"));
-const commitTemplate = readFileAsync(join(TEMPLATE_DIR, "commit-template.hbs"));
+const releaseNotesTemplatePath = path.resolve(__dirname, 'build/release-notes.hbs')
+const commitTemplateDir = "node_modules/semantic-release-gitmoji/lib/assets/templates";
+
+const releaseNotesTemplate = readFileAsync(releaseNotesTemplatePath);
+const commitTemplate = readFileAsync(join(commitTemplateDir, "commit-template.hbs"));
 
 module.exports = {
   branches: [
@@ -31,10 +31,10 @@ module.exports = {
         releaseRules: {
           major: [":boom:"],
           minor: [":sparkles:"],
-          patch: [":bug:", ":ambulance:", ":lock:", ":lipstick:"],
+          patch: [":bug:", ":ambulance:", ":lock:", ":lipstick:", "arrow_up"],
         },
         releaseNotes: {
-          template,
+          template: releaseNotesTemplate,
           partials: { commitTemplate },
           helpers: {
             datetime: function (format = "UTC:yyyy-mm-dd") {

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -3,11 +3,17 @@ const dateFormat = require("dateformat");
 const { join } = require("node:path");
 const readFileAsync = promisify(require("fs").readFile);
 
-const releaseNotesTemplatePath = path.resolve(__dirname, 'build/release-notes.hbs')
-const commitTemplateDir = "node_modules/semantic-release-gitmoji/lib/assets/templates";
+const releaseNotesTemplatePath = path.resolve(
+  __dirname,
+  "build/release-notes.hbs"
+);
+const commitTemplateDir =
+  "node_modules/semantic-release-gitmoji/lib/assets/templates";
 
 const releaseNotesTemplate = readFileAsync(releaseNotesTemplatePath);
-const commitTemplate = readFileAsync(join(commitTemplateDir, "commit-template.hbs"));
+const commitTemplate = readFileAsync(
+  join(commitTemplateDir, "commit-template.hbs")
+);
 
 module.exports = {
   branches: [

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ This project uses [semantic-release](https://github.com/semantic-release/semanti
 
 It follows [gitmoji commit conventions](https://gitmoji.dev/). For example:
 
-| gitmoji                             | Sample Commit message                                                                                                               | Release type  |
-|-------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| :lipstick: :lock: :ambulance: :bug: | `:lipstick` / `:lock:` / `:ambulance:` / `:bug: stop graphite breaking when too much pressure applied`                              | Patch Release |
-| :sparkles:                          | `:sparkles: add 'graphiteWidth' option`                                                                                             | Minor Release |
-| :boom:                              | `:boom: The graphiteWidth option has been removed.`<br>`The default graphite width of 10mm is always used for performance reasons.` | Major Release |
+| gitmoji                                        | Sample Commit message                                                                    | Release type  |
+|------------------------------------------------|------------------------------------------------------------------------------------------|---------------|
+| :lipstick: :lock: :ambulance: :bug: :arrow_up: | `:lipstick` / `:lock:` / `:ambulance:` / `:bug:` / `:arrow_up: some cool commit message` | Patch Release |
+| :sparkles:                                     | `:sparkles: some new feature added`                                                      | Minor Release |
+| :boom:                                         | `:boom: some breaking change happened.`<br>` Here is how to fix it: `                    | Major Release |
 
 ## License
 

--- a/build/release-notes.hbs
+++ b/build/release-notes.hbs
@@ -1,0 +1,58 @@
+{{#if compareUrl}}
+# [v{{nextRelease.version}}]({{compareUrl}}) ({{datetime "UTC:yyyy-mm-dd"}})
+{{else}}
+# v{{nextRelease.version}} ({{datetime "UTC:yyyy-mm-dd"}})
+{{/if}}
+
+{{#with commits}}
+
+{{#if boom}}
+## 💥 Breaking Changes
+{{#each boom}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{#if sparkles}}
+## ✨ New Features
+{{#each sparkles}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{#if ambulance}}
+## 🚑 Critical Hotfixes
+{{#each ambulance}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{#if bug}}
+## 🐛 Bug Fixes
+{{#each bug}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{#if lipstick}}
+## 💄 Design Fixes and Updates
+{{#each lipstick}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{#if lock}}
+## 🔒 Security Issues
+{{#each lock}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{#if arrow_up}}
+## ⬆️ Dependency Upgrade
+{{#each arrow_up}}
+- {{> commitTemplate}}
+{{/each}}
+{{/if}}
+
+{{/with}}


### PR DESCRIPTION
closes #375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README to include `:arrow_up:` gitmoji in commit conventions
	- Enhanced release notes template with more structured categorization

- **Configuration**
	- Updated release configuration to use new release notes template path
	- Added patch rule for `:arrow_up:` commits
	- Expanded ESLint ignore patterns to include the `build` directory
	- Added `build` directory to Prettier ignore list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->