### PR TITLE
:boom: 395: add new required variable id to all form fields to ensure a11y

### DIFF
--- a/src/components/Form/MucCheckbox.stories.ts
+++ b/src/components/Form/MucCheckbox.stories.ts
@@ -20,6 +20,7 @@ export default {
 
 export const Default = {
   args: {
+    id: "default",
     label: "This is a checkbox - click me",
   },
 };

--- a/src/components/Form/MucCheckbox.vue
+++ b/src/components/Form/MucCheckbox.vue
@@ -4,25 +4,34 @@
     @click="clickedCheckbox"
   >
     <input
+      :id="'checkbox-' + id"
       class="m-checkboxes__input"
       name="checkbox"
       type="checkbox"
       :checked="modelValue"
       @click.stop="clickedCheckbox"
     />
-    <label class="m-label m-checkboxes__label">
+    <label
+      class="m-label m-checkboxes__label"
+      :for="'checkbox-' + id"
+    >
       {{ label }}
     </label>
   </div>
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
 /**
  * Input value from the checkbox component.
  */
 const modelValue = defineModel<boolean>({ default: false });
 
-defineProps<{
+const { label } = defineProps<{
+  /**
+   * id of checkbox
+   */
+  id: string;
   /**
    * Label is displayed to the right of the checkbox as information for the user.
    */

--- a/src/components/Form/MucCheckbox.vue
+++ b/src/components/Form/MucCheckbox.vue
@@ -28,7 +28,7 @@ const modelValue = defineModel<boolean>({ default: false });
 
 const { label } = defineProps<{
   /**
-   * id of checkbox
+   *  Unique identifier for the checkbox. Required property used to associate the checkbox with its label and hint text for accessibility.
    */
   id: string;
   /**

--- a/src/components/Form/MucCheckbox.vue
+++ b/src/components/Form/MucCheckbox.vue
@@ -21,7 +21,6 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
 /**
  * Input value from the checkbox component.
  */

--- a/src/components/Form/MucCheckboxGroup.stories.ts
+++ b/src/components/Form/MucCheckboxGroup.stories.ts
@@ -22,7 +22,7 @@ export const NotCollapsable = () => ({
   template: `
       <MucCheckboxGroup heading="Collapsable checkbox group ">
          <template #checkboxes>
-           <MucCheckbox v-for="index in 4" :key="index" :label="'not-collapsed-' + index" />
+           <MucCheckbox v-for="index in 4" :key="index" :label="'not-collapsed-' + index" :id="index"/>
          </template>
       </MucCheckboxGroup>
   `,
@@ -33,10 +33,10 @@ export const Collapsable = () => ({
   template: `
       <MucCheckboxGroup heading="Collapsable checkbox group ">
          <template #checkboxes>
-           <MucCheckbox v-for="index in 4" :key="index" :label="'not-collapsed-' + index" />
+           <MucCheckbox v-for="index in 4" :key="index" :label="'not-collapsed-' + index" :id="'not-collapsed-' + index" />
          </template>
          <template #collapsableCheckboxes>
-           <MucCheckbox v-for="index in 4" :key="index" :label="'collapsed-' + index" />
+           <MucCheckbox v-for="index in 4" :key="index" :label="'collapsed-' + index" :id="'collapsed-' + index" />
          </template>  
       </MucCheckboxGroup>
   `,

--- a/src/components/Form/MucInput.stories.ts
+++ b/src/components/Form/MucInput.stories.ts
@@ -20,6 +20,7 @@ export default {
 
 export const Default = {
   args: {
+    id: "default",
     placeholder: "Please type here",
   },
 };
@@ -27,6 +28,7 @@ export const Default = {
 export const HintAndLabel = {
   args: {
     ...Default.args,
+    id: "hint-and-label",
     hint: "This is a hint",
     label: "This is a label",
   },
@@ -35,6 +37,7 @@ export const HintAndLabel = {
 export const Password = {
   args: {
     ...Default.args,
+    id: "password",
     type: "password",
     modelValue: "password",
     hint: "The input text is 'password'",
@@ -44,6 +47,7 @@ export const Password = {
 export const Error = {
   args: {
     ...Default.args,
+    id: "error",
     errorMsg: "Oops, an error occurred",
     hint: "An error message triggers the error state",
   },
@@ -52,6 +56,7 @@ export const Error = {
 export const Prefix = {
   args: {
     ...Default.args,
+    id: "prefix",
     prefix: "Prefix",
   },
 };
@@ -59,6 +64,7 @@ export const Prefix = {
 export const SuffixIcon = {
   args: {
     ...Default.args,
+    id: "suffix-icon",
     suffixIcon: "search",
   },
 };
@@ -66,6 +72,7 @@ export const SuffixIcon = {
 export const Search = {
   args: {
     ...Default.args,
+    id: "search",
     type: "search",
     dataList: ["chocolate", "coconut", "vanilla", "mint"],
   },
@@ -73,18 +80,21 @@ export const Search = {
 
 export const Color = {
   args: {
+    id: "color",
     type: "color",
   },
 };
 
 export const Date = {
   args: {
+    id: "date",
     type: "date",
   },
 };
 
 export const Datetime_Local = {
   args: {
+    id: "datetime",
     type: "datetime-local",
   },
 };

--- a/src/components/Form/MucInput.vue
+++ b/src/components/Form/MucInput.vue
@@ -32,7 +32,7 @@
         class="m-input autocomplete-input"
         :type="type"
         v-model="modelValue"
-        :aria-describedby="'input-hint-' + id"
+        :aria-describedby="hint ? 'input-hint-' + id : undefined"
         :placeholder="placeholder"
         :required="required"
       />
@@ -67,6 +67,8 @@
       id="text-input-error"
       v-if="errorMsg"
       tabindex="0"
+      role="alert"
+      aria-live="polite"
     >
       {{ errorMsg }}
     </form-error-message>
@@ -100,7 +102,7 @@ const {
   dataList = [] as string[],
 } = defineProps<{
   /**
-   * id of input
+   *  Unique identifier for the input. Required property used to associate the input with its label and hint text for accessibility.
    */
   id: string;
   /**

--- a/src/components/Form/MucInput.vue
+++ b/src/components/Form/MucInput.vue
@@ -5,15 +5,16 @@
   >
     <label
       v-if="label"
-      for="search-input"
+      :for="'input-' + id"
       class="m-label"
       :class="{ 'm-label--optional': !required }"
     >
       {{ label }}
     </label>
     <p
+      v-if="hint"
       class="m-hint"
-      id="text-input-hint"
+      :id="'input-hint-' + id"
     >
       {{ hint }}
     </p>
@@ -27,10 +28,11 @@
         </span>
       </div>
       <input
+        :id="'input-' + id"
         class="m-input autocomplete-input"
         :type="type"
         v-model="modelValue"
-        :aria-describedby="type + '-input'"
+        :aria-describedby="'input-hint-' + id"
         :placeholder="placeholder"
         :required="required"
       />
@@ -64,6 +66,7 @@
     <form-error-message
       id="text-input-error"
       v-if="errorMsg"
+      tabindex="0"
     >
       {{ errorMsg }}
     </form-error-message>
@@ -96,6 +99,10 @@ const {
   type = "text",
   dataList = [] as string[],
 } = defineProps<{
+  /**
+   * id of input
+   */
+  id: string;
   /**
    * Displays error message and highlights the input form with a red border.
    */

--- a/src/components/Form/MucRadioButton.stories.ts
+++ b/src/components/Form/MucRadioButton.stories.ts
@@ -24,8 +24,8 @@ export const Default = () => ({
   template: `
       <MucRadioButtonGroup heading="Checkbox group" model-value="">
          <template v-slot:default>
-           <MucRadioButton value="first" label="first option" hint="This is a hint for this radiobutton"/>
-           <MucRadioButton v-for="index in 3" :key="index" :label="'other option-' + index" :value="'val-' + index"/>
+           <MucRadioButton value="first" label="first option" hint="This is a hint for this radiobutton" id="first"/>
+           <MucRadioButton v-for="index in 3" :key="index" :label="'other option-' + index" :value="'val-' + index" :id="'other-option' + index"/>
          </template>
       </MucRadioButtonGroup>
   `,

--- a/src/components/Form/MucRadioButton.vue
+++ b/src/components/Form/MucRadioButton.vue
@@ -19,8 +19,8 @@
     >
       {{ label }}
       <span
-          :id="'radio-hint-' + id"
-          class="m-hint"
+        :id="'radio-hint-' + id"
+        class="m-hint"
       >
         {{ hint }}
       </span>

--- a/src/components/Form/MucRadioButton.vue
+++ b/src/components/Form/MucRadioButton.vue
@@ -7,7 +7,7 @@
       :id="'radio-' + id"
       class="m-radios__input"
       type="radio"
-      :aria-describedby="'radio-hint-' + id"
+      :aria-describedby="hint ? 'radio-hint-' + id : undefined"
       :checked="isChecked"
       :disabled="isDisabled"
       @click.stop="clicked"
@@ -35,7 +35,7 @@ import { RadioButtonGroupKey } from "./MucRadioButtonTypes";
 
 const { value, disabled = false } = defineProps<{
   /**
-   * id of radiobutton
+   *  Unique identifier for the radiobutton. Required property used to associate the radiobutton with its label and hint text for accessibility.
    */
   id: string;
   /**

--- a/src/components/Form/MucRadioButton.vue
+++ b/src/components/Form/MucRadioButton.vue
@@ -4,18 +4,24 @@
     v-if="isInRadioButtonGroup"
   >
     <input
+      :id="'radio-' + id"
       class="m-radios__input"
       type="radio"
+      :aria-describedby="'radio-hint-' + id"
       :checked="isChecked"
       :disabled="isDisabled"
       @click.stop="clicked"
     />
     <label
       class="m-label m-radios__label"
+      :for="'radio-' + id"
       @click="clicked"
     >
       {{ label }}
-      <span class="m-hint">
+      <span
+          :id="'radio-hint-' + id"
+          class="m-hint"
+      >
         {{ hint }}
       </span>
     </label>
@@ -28,6 +34,10 @@ import { computed, inject } from "vue";
 import { RadioButtonGroupKey } from "./MucRadioButtonTypes";
 
 const { value, disabled = false } = defineProps<{
+  /**
+   * id of radiobutton
+   */
+  id: string;
   /**
    * value for this radiobutton
    */

--- a/src/components/Form/MucSelect.stories.ts
+++ b/src/components/Form/MucSelect.stories.ts
@@ -18,6 +18,7 @@ export default {
 
 export const Default = {
   args: {
+    id: "default",
     modelValue: {
       id: "1",
       name: "Object 1",
@@ -54,6 +55,7 @@ export const Default = {
 export const MultiSelect = {
   args: {
     ...Default.args,
+    id: "multi-select",
     label: "Select multiple objects",
     multiple: true,
   },
@@ -61,6 +63,7 @@ export const MultiSelect = {
 
 export const StringSelect = {
   args: {
+    id: "string-select",
     modelValue: "String 1",
     items: ["String 1", "String 2", "String 3", "String 4"],
     label: "Select strings",

--- a/src/components/Form/MucSelect.vue
+++ b/src/components/Form/MucSelect.vue
@@ -4,9 +4,9 @@
     ref="selectComponent"
   >
     <label
-        v-if="label"
-        :for="'select-' + id"
-        class="m-label"
+      v-if="label"
+      :for="'select-' + id"
+      class="m-label"
     >
       {{ label }}
     </label>

--- a/src/components/Form/MucSelect.vue
+++ b/src/components/Form/MucSelect.vue
@@ -3,12 +3,17 @@
     class="m-form-group"
     ref="selectComponent"
   >
-    <label class="m-label">
+    <label
+        v-if="label"
+        :for="'select-' + id"
+        class="m-label"
+    >
       {{ label }}
     </label>
     <p
-      v-if="!!hint"
+      v-if="hint"
       class="m-hint"
+      :id="'select-hint-' + id"
     >
       {{ hint }}
     </p>
@@ -17,8 +22,10 @@
       :class="selectType"
     >
       <input
+        :id="'select-' + id"
         type="text"
         class="m-input m-combobox m-combobox--single"
+        :aria-describedby="'select-hint-' + id"
         v-model="searchValue"
         @click="openItemList"
       />
@@ -111,6 +118,10 @@ const {
   noItemFoundMessage = "No items found.",
   itemTitle = "title",
 } = defineProps<{
+  /**
+   * id of select
+   */
+  id: string;
   /**
    * List of items to be available
    */

--- a/src/components/Form/MucSelect.vue
+++ b/src/components/Form/MucSelect.vue
@@ -25,7 +25,7 @@
         :id="'select-' + id"
         type="text"
         class="m-input m-combobox m-combobox--single"
-        :aria-describedby="'select-hint-' + id"
+        :aria-describedby="hint ? 'select-hint-' + id : undefined"
         v-model="searchValue"
         @click="openItemList"
       />
@@ -119,7 +119,7 @@ const {
   itemTitle = "title",
 } = defineProps<{
   /**
-   * id of select
+   * Unique identifier for the select. Required property used to associate the select with its label and hint text for accessibility.
    */
   id: string;
   /**

--- a/src/components/Form/MucTextArea.stories.ts
+++ b/src/components/Form/MucTextArea.stories.ts
@@ -43,7 +43,7 @@ export const Required = {
 export const BigTextArea = {
   args: {
     ...Default.args,
-    id: "big-test-area",
+    id: "big-text-area",
     rows: 7,
     label: "Big textarea",
     hint: "Write a lot of text",

--- a/src/components/Form/MucTextArea.stories.ts
+++ b/src/components/Form/MucTextArea.stories.ts
@@ -18,6 +18,7 @@ export default {
 
 export const Default = {
   args: {
+    id: "default",
     placeholder: "Write some very long text here",
   },
 };
@@ -25,6 +26,7 @@ export const Default = {
 export const Error = {
   args: {
     ...Default.args,
+    id: "error",
     errorMsg: "An error occured",
   },
 };
@@ -33,6 +35,7 @@ export const Required = {
   args: {
     label: "Required textarea",
     ...Default.args,
+    id: "required",
     required: true,
   },
 };
@@ -40,6 +43,7 @@ export const Required = {
 export const BigTextArea = {
   args: {
     ...Default.args,
+    id: "big-test-area",
     rows: 7,
     label: "Big textarea",
     hint: "Write a lot of text",

--- a/src/components/Form/MucTextArea.vue
+++ b/src/components/Form/MucTextArea.vue
@@ -22,7 +22,7 @@
       <textarea
         :id="'textarea-' + id"
         class="m-textarea"
-        :aria-describedby="'textarea-hint-' + id"
+        :aria-describedby="hint ? 'textarea-hint-' + id : undefined"
         :rows="rows"
         :placeholder="placeholder"
         v-model="modelValue"
@@ -31,6 +31,8 @@
     <form-error-message
       v-if="errorMsg"
       tabindex="0"
+      role="alert"
+      aria-live="polite"
     >
       {{ errorMsg }}
     </form-error-message>
@@ -51,7 +53,7 @@ const {
   required = false,
 } = defineProps<{
   /**
-   * id of textarea
+   * Unique identifier for the textarea. Required property used  to associate the textarea with its label and hint text for accessibility.
    */
   id: string;
   /**

--- a/src/components/Form/MucTextArea.vue
+++ b/src/components/Form/MucTextArea.vue
@@ -12,9 +12,9 @@
       {{ label }}
     </label>
     <p
-        v-if="hint"
-        :id="'textarea-hint-' + id"
-        class="m-hint"
+      v-if="hint"
+      :id="'textarea-hint-' + id"
+      class="m-hint"
     >
       {{ hint }}
     </p>
@@ -29,8 +29,8 @@
       />
     </div>
     <form-error-message
-        v-if="errorMsg"
-        tabindex="0"
+      v-if="errorMsg"
+      tabindex="0"
     >
       {{ errorMsg }}
     </form-error-message>

--- a/src/components/Form/MucTextArea.vue
+++ b/src/components/Form/MucTextArea.vue
@@ -5,25 +5,33 @@
   >
     <label
       v-if="label"
-      for="textarea"
+      :for="'textarea-' + id"
       class="m-label"
       :class="{ 'm-label--optional': !required }"
     >
       {{ label }}
     </label>
-    <p class="m-hint">
+    <p
+        v-if="hint"
+        :id="'textarea-hint-' + id"
+        class="m-hint"
+    >
       {{ hint }}
     </p>
     <div class="m-input-wrapper">
       <textarea
+        :id="'textarea-' + id"
         class="m-textarea"
+        :aria-describedby="'textarea-hint-' + id"
         :rows="rows"
-        aria-describedby="textarea input"
         :placeholder="placeholder"
         v-model="modelValue"
       />
     </div>
-    <form-error-message v-if="errorMsg">
+    <form-error-message
+        v-if="errorMsg"
+        tabindex="0"
+    >
       {{ errorMsg }}
     </form-error-message>
   </div>
@@ -42,6 +50,10 @@ const {
   rows = 3,
   required = false,
 } = defineProps<{
+  /**
+   * id of textarea
+   */
+  id: string;
   /**
    * Displays error message and highlights the input form with a red border.
    */


### PR DESCRIPTION
**Description**

Add ids to form fields so that the screen reader can access the labels and hints.

**Reference**

closes #395 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added unique `id` attributes to form components (Checkbox, Input, Radio Button, Select, TextArea) to improve accessibility and component identification.

- **Accessibility Improvements**
	- Enhanced form components with dynamic `id` bindings
	- Improved label-input associations
	- Added `aria-describedby` attributes for better screen reader support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->