### PR TITLE
🐛 change muc callout headline to h2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@eslint/compat": "1.3.1",
         "@eslint/js": "9.30.1",
+        "@muenchen/muc-patternlab-vue": "^5.4.0",
         "@splidejs/vue-splide": "0.6.12",
         "choices.js": "11.1.0",
         "patch-package": "8.0.0"
@@ -1232,6 +1233,23 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@muenchen/muc-patternlab-vue": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@muenchen/muc-patternlab-vue/-/muc-patternlab-vue-5.4.0.tgz",
+      "integrity": "sha512-07qzZeAsU4box4989VpSJfVD5dp3BicgX2ef0lgbZDKY8uQRy+QcmCsSPBbLRGIyy3YOTMuDVvBZYfb2VkPjUA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/compat": "1.3.1",
+        "@eslint/js": "9.30.1",
+        "@splidejs/vue-splide": "0.6.12",
+        "choices.js": "11.1.0",
+        "patch-package": "8.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.10"
+      }
     },
     "node_modules/@muenchen/prettier-codeformat": {
       "version": "1.0.2",
@@ -12698,6 +12716,7 @@
     },
     "node_modules/vue-component-type-helpers": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.0.1.tgz",
       "integrity": "sha512-j23mCB5iEbGsyIhnVdXdWUOg+UdwmVxpKnYYf2j+4ppCt5VSFXKjwu9YFt0QYxUaf5G99PuHsVfRScjHCRSsGQ==",
       "dev": true,
       "license": "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       "dependencies": {
         "@eslint/compat": "1.3.1",
         "@eslint/js": "9.30.1",
-        "@muenchen/muc-patternlab-vue": "^5.4.0",
         "@splidejs/vue-splide": "0.6.12",
         "choices.js": "11.1.0",
         "patch-package": "8.0.0"
@@ -1233,23 +1232,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@muenchen/muc-patternlab-vue": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@muenchen/muc-patternlab-vue/-/muc-patternlab-vue-5.4.0.tgz",
-      "integrity": "sha512-07qzZeAsU4box4989VpSJfVD5dp3BicgX2ef0lgbZDKY8uQRy+QcmCsSPBbLRGIyy3YOTMuDVvBZYfb2VkPjUA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint/compat": "1.3.1",
-        "@eslint/js": "9.30.1",
-        "@splidejs/vue-splide": "0.6.12",
-        "choices.js": "11.1.0",
-        "patch-package": "8.0.0"
-      },
-      "peerDependencies": {
-        "vue": "^3.5.10"
-      }
     },
     "node_modules/@muenchen/prettier-codeformat": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   "dependencies": {
     "@eslint/compat": "1.3.1",
     "@eslint/js": "9.30.1",
-    "@muenchen/muc-patternlab-vue": "^5.4.0",
     "@splidejs/vue-splide": "0.6.12",
     "choices.js": "11.1.0",
     "patch-package": "8.0.0"

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "11.0.3",
     "@storybook/addon-a11y": "9.0.16",
+    "@storybook/addon-docs": "9.0.16",
     "@storybook/addon-links": "9.0.16",
     "@storybook/vue3-vite": "9.0.16",
-    "@storybook/addon-docs": "9.0.16",
     "@tsconfig/node20": "20.1.6",
     "@types/jsdom": "21.1.7",
     "@types/node": "22.14.0",
@@ -60,8 +60,8 @@
     "@vue/test-utils": "2.4.6",
     "@vue/tsconfig": "0.7.0",
     "eslint": "9.30.1",
-    "eslint-plugin-vue": "10.3.0",
     "eslint-plugin-storybook": "9.0.16",
+    "eslint-plugin-vue": "10.3.0",
     "jsdom": "26.1.0",
     "prettier": "3.6.2",
     "rimraf": "6.0.1",
@@ -77,6 +77,7 @@
   "dependencies": {
     "@eslint/compat": "1.3.1",
     "@eslint/js": "9.30.1",
+    "@muenchen/muc-patternlab-vue": "^5.4.0",
     "@splidejs/vue-splide": "0.6.12",
     "choices.js": "11.1.0",
     "patch-package": "8.0.0"
@@ -87,4 +88,3 @@
     }
   }
 }
-

--- a/src/components/Callout/MucCallout.vue
+++ b/src/components/Callout/MucCallout.vue
@@ -13,9 +13,9 @@
       </div>
       <div class="m-callout__body">
         <div class="m-callout__body__inner">
-          <div class="m-callout__headline">
+          <h2 class="m-callout__headline">
             <slot name="header" />
-          </div>
+          </h2>
           <div class="m-callout__content">
             <p>
               <slot


### PR DESCRIPTION
**Description**

Changed muc-callout-headline to h2 to make it easier for screen-readers to navigate.

**Reference**

Issues #505 
