### PR TITLE
✨ inlinestyle for disabled plus-/minus buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12678,6 +12678,7 @@
     },
     "node_modules/vue-component-type-helpers": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.0.7.tgz",
       "integrity": "sha512-TvyUcFXmjZcXUvU+r1MOyn4/vv4iF+tPwg5Ig33l/FJ3myZkxeQpzzQMLMFWcQAjr6Xs7BRwVy/TwbmNZUA/4w==",
       "dev": true,
       "license": "MIT"

--- a/src/components/Form/MucCounter.vue
+++ b/src/components/Form/MucCounter.vue
@@ -147,12 +147,6 @@ const disableMinus = computed(
 </script>
 
 <style scoped>
-:deep(.counter-btn--disabled) {
-  background-color: transparent;
-  border-color: #7a8d9f;
-  color: #7a8d9f;
-}
-
 .content-centered {
   display: flex;
   justify-content: center;
@@ -165,6 +159,12 @@ const disableMinus = computed(
   justify-content: left;
   align-items: center;
   height: 100%;
+}
+
+.counter-btn--disabled {
+  background-color: transparent;
+  border-color: #7a8d9f;
+  color: #7a8d9f;
 }
 
 .grid {

--- a/src/components/Form/MucCounter.vue
+++ b/src/components/Form/MucCounter.vue
@@ -6,11 +6,12 @@
           v-on:click="clickedMinus"
           variant="secondary"
           :disabled="disableMinus"
-          :aria-label="
-            'Anzahl ' + label + ' reduzieren auf ' + (modelValue - 1)
-          "
+          :aria-label="'Anzahl ' + label + ' reduzieren auf ' + (modelValue - 1)"
+          :style="disableMinus ? { backgroundColor:'transparent', border:'1px solid #7A8D9F' } : null"
         >
-          <template #default><muc-icon icon="minus" /></template>
+          <template #default>
+            <muc-icon icon="minus" :style="disableMinus ? { color:'#7A8D9F' } : null" />
+          </template>
         </muc-button>
       </div>
       <p tabindex="0">
@@ -30,8 +31,11 @@
           variant="secondary"
           :disabled="disablePlus"
           :aria-label="'Anzahl ' + label + ' erhöhen auf ' + (modelValue + 1)"
+          :style="disablePlus ? { backgroundColor:'transparent', border:'1px solid #7A8D9F' } : null"
         >
-          <template #default><muc-icon icon="plus" /></template>
+          <template #default>
+            <muc-icon icon="plus" :style="disablePlus ? { color:'#7A8D9F' } : null" />
+          </template>
         </muc-button>
       </div>
     </div>

--- a/src/components/Form/MucCounter.vue
+++ b/src/components/Form/MucCounter.vue
@@ -6,11 +6,20 @@
           v-on:click="clickedMinus"
           variant="secondary"
           :disabled="disableMinus"
-          :aria-label="'Anzahl ' + label + ' reduzieren auf ' + (modelValue - 1)"
-          :style="disableMinus ? { backgroundColor:'transparent', border:'1px solid #7A8D9F' } : null"
+          :aria-label="
+            'Anzahl ' + label + ' reduzieren auf ' + (modelValue - 1)
+          "
+          :style="
+            disableMinus
+              ? { backgroundColor: 'transparent', border: '1px solid #7A8D9F' }
+              : null
+          "
         >
           <template #default>
-            <muc-icon icon="minus" :style="disableMinus ? { color:'#7A8D9F' } : null" />
+            <muc-icon
+              icon="minus"
+              :style="disableMinus ? { color: '#7A8D9F' } : null"
+            />
           </template>
         </muc-button>
       </div>
@@ -31,10 +40,17 @@
           variant="secondary"
           :disabled="disablePlus"
           :aria-label="'Anzahl ' + label + ' erhöhen auf ' + (modelValue + 1)"
-          :style="disablePlus ? { backgroundColor:'transparent', border:'1px solid #7A8D9F' } : null"
+          :style="
+            disablePlus
+              ? { backgroundColor: 'transparent', border: '1px solid #7A8D9F' }
+              : null
+          "
         >
           <template #default>
-            <muc-icon icon="plus" :style="disablePlus ? { color:'#7A8D9F' } : null" />
+            <muc-icon
+              icon="plus"
+              :style="disablePlus ? { color: '#7A8D9F' } : null"
+            />
           </template>
         </muc-button>
       </div>

--- a/src/components/Form/MucCounter.vue
+++ b/src/components/Form/MucCounter.vue
@@ -9,17 +9,10 @@
           :aria-label="
             'Anzahl ' + label + ' reduzieren auf ' + (modelValue - 1)
           "
-          :style="
-            disableMinus
-              ? { backgroundColor: 'transparent', border: '1px solid #7A8D9F' }
-              : null
-          "
+          :class="{ 'counter-btn--disabled': disableMinus }"
         >
           <template #default>
-            <muc-icon
-              icon="minus"
-              :style="disableMinus ? { color: '#7A8D9F' } : null"
-            />
+            <muc-icon icon="minus" />
           </template>
         </muc-button>
       </div>
@@ -40,17 +33,10 @@
           variant="secondary"
           :disabled="disablePlus"
           :aria-label="'Anzahl ' + label + ' erhöhen auf ' + (modelValue + 1)"
-          :style="
-            disablePlus
-              ? { backgroundColor: 'transparent', border: '1px solid #7A8D9F' }
-              : null
-          "
+          :class="{ 'counter-btn--disabled': disablePlus }"
         >
           <template #default>
-            <muc-icon
-              icon="plus"
-              :style="disablePlus ? { color: '#7A8D9F' } : null"
-            />
+            <muc-icon icon="plus" />
           </template>
         </muc-button>
       </div>
@@ -161,6 +147,12 @@ const disableMinus = computed(
 </script>
 
 <style scoped>
+:deep(.counter-btn--disabled) {
+  background-color: transparent;
+  border-color: #7a8d9f;
+  color: #7a8d9f;
+}
+
 .content-centered {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
**Description**

For ZMS, we want transparent disabled plus- an minus-buttons with grey icons and grey border.

**Reference**

Issues #545 
