### PR TITLE
Remove focus from non-interactive elements

### DIFF
--- a/src/components/Form/MucCounter.vue
+++ b/src/components/Form/MucCounter.vue
@@ -16,7 +16,7 @@
           </template>
         </muc-button>
       </div>
-      <p tabindex="0">
+      <p>
         <strong
           class="content-centered"
           style="color: var(--color-brand-main-blue)"

--- a/src/components/Form/MucSelect.vue
+++ b/src/components/Form/MucSelect.vue
@@ -7,7 +7,6 @@
       v-if="label"
       :for="'select-' + id"
       class="m-label"
-      tabindex="0"
     >
       {{ label }}
     </label>


### PR DESCRIPTION
**Description**

This PR addresses an accessibility issue reported by Pfennigparade, an accessibility audit organization (see reference).

Two of your components that we use in our [zmscitizenview](https://github.com/it-at-m/eappointment/tree/main/zmscitizenview) contain non-interactive elements that are taken into account in the tab order by `tabindex=0`.

According to EN 301549 (Annex C) and WCAG Success Criterion 2.4.3 – Focus Order, only interactive elements should be reachable via keyboard navigation.

**Reference**

[Pfennigparade (Issue #7)](https://github.com/user-attachments/files/22737678/pfennigparade-issue-7.pdf)
