### PR TITLE
✨ greater focus on hovered days

### DIFF
--- a/src/components/Calendar/MucCalendar.css
+++ b/src/components/Calendar/MucCalendar.css
@@ -24,7 +24,7 @@
 .muc-calendar-item:hover,
 .muc-calendar-item:focus {
   outline: none;
-  border: 1px solid #005a9f;
+  border: 1px solid var(--mde-color-brand-mde-blue);
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: border-color 0.1s ease-out;

--- a/src/components/Calendar/MucCalendar.css
+++ b/src/components/Calendar/MucCalendar.css
@@ -24,7 +24,9 @@
 .muc-calendar-item:hover,
 .muc-calendar-item:focus {
   outline: none;
-  border: 1px solid var(--color-neutrals-blue);
+  border: 1px solid #005A9F;
+  text-decoration: underline;
+  text-underline-offset: 2px;
   transition: border-color 0.1s ease-out;
   cursor: pointer;
 }

--- a/src/components/Calendar/MucCalendar.css
+++ b/src/components/Calendar/MucCalendar.css
@@ -24,7 +24,7 @@
 .muc-calendar-item:hover,
 .muc-calendar-item:focus {
   outline: none;
-  border: 1px solid #005A9F;
+  border: 1px solid #005a9f;
   text-decoration: underline;
   text-underline-offset: 2px;
   transition: border-color 0.1s ease-out;


### PR DESCRIPTION
**Description**

Set the frame color on hover/focus to MDE Blue (#005A9F) and underline the day that is hovered over.


**Reference**

Issues #590 
