### PR TITLE
:bug: fix FormErrorMessage accessibility

### DIFF
--- a/src/components/Form/FormErrorMessage.vue
+++ b/src/components/Form/FormErrorMessage.vue
@@ -6,7 +6,6 @@ import { MucIcon } from "../Icon";
   <p
     class="m-error-message"
     role="alert"
-    aria-live="polite"
   >
     <muc-icon
       class="icon icon--before"


### PR DESCRIPTION
**Description**

Do not use `role="alert"` and `aria-live="polite"` together.
https://developer.mozilla.org/de/docs/Web/Accessibility/ARIA/Guides/Live_regions#rollen_mit_impliziten_live-region-attributen

**Reference**

Issues [DPKK1-991](https://jira.muenchen.de/browse/DPKK1-991)
