### PR TITLE
:bug: align MucStepper markup with Patternlab form-steps

### DIFF
--- a/src/components/Stepper/MucStepper.test.ts
+++ b/src/components/Stepper/MucStepper.test.ts
@@ -71,11 +71,9 @@ describe("MucStepper.vue", () => {
     const buttons = wrapper.findAll("button.m-form-step__button");
     expect(buttons).toHaveLength(2);
     expect(buttons[0].text()).toContain("Zurück zu Schritt: Order");
-    expect(buttons[0].find("div.m-form-step__icon").exists()).toBe(true);
+    expect(buttons[0].find("span.m-form-step__icon").exists()).toBe(true);
 
-    const decorativeIcons = wrapper
-      .findAll("div.m-form-step__icon")
-      .filter((icon) => !icon.element.closest("button"));
+    const decorativeIcons = wrapper.findAll("div.m-form-step__icon");
     expect(decorativeIcons).toHaveLength(2);
     decorativeIcons.forEach((icon) => {
       expect(icon.attributes("tabindex")).toBeUndefined();

--- a/src/components/Stepper/MucStepper.test.ts
+++ b/src/components/Stepper/MucStepper.test.ts
@@ -1,0 +1,97 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import MucStepper from "./MucStepper.vue";
+
+const stepItems = [
+  { id: "1", label: "Order", icon: "shopping-cart" },
+  { id: "2", label: "Delivery", icon: "calendar" },
+  { id: "3", label: "Contact", icon: "mail" },
+  { id: "4", label: "Overview", icon: "information" },
+];
+
+const mountStepper = (activeItem = "2", disablePreviousSteps = false) =>
+  mount(MucStepper, {
+    props: {
+      stepItems,
+      activeItem,
+      disablePreviousSteps,
+    },
+    global: {
+      stubs: {
+        MucIcon: {
+          props: ["icon"],
+          template: '<span data-test="muc-icon" :data-icon="icon"></span>',
+        },
+      },
+    },
+  });
+
+describe("MucStepper.vue", () => {
+  it("renders Patternlab heading and an ol without redundant list attributes", () => {
+    const wrapper = mountStepper("2");
+
+    const heading = wrapper.find("h2.m-form-steps__heading");
+    expect(heading.exists()).toBe(true);
+    expect(heading.classes()).toContain("visually-hidden");
+    expect(heading.find(".m-form-steps__current-step").text()).toBe("2");
+    expect(heading.find(".m-form-steps__total-steps").text()).toContain(
+      "von 4"
+    );
+    expect(heading.find(".m-form-steps__heading-text").text()).toBe("Delivery");
+
+    const list = wrapper.find("ol.m-form-steps");
+    expect(list.exists()).toBe(true);
+    expect(list.attributes("role")).toBeUndefined();
+    expect(list.attributes("aria-label")).toBeUndefined();
+  });
+
+  it("puts aria-current on the current list item and keeps step icons when done", () => {
+    const wrapper = mountStepper("3");
+
+    const steps = wrapper.findAll("li.m-form-step");
+    expect(steps).toHaveLength(4);
+    expect(steps[2].classes()).toContain("m-form-step--current");
+    expect(steps[2].attributes("aria-current")).toBe("step");
+    expect(steps[0].attributes("aria-current")).toBeUndefined();
+    expect(steps[0].classes()).not.toContain("show-cursor");
+
+    const icons = wrapper.findAll('[data-test="muc-icon"]');
+    expect(icons[0].attributes("data-icon")).toBe("shopping-cart");
+    expect(icons[1].attributes("data-icon")).toBe("calendar");
+    expect(icons[2].attributes("data-icon")).toBe("mail");
+    expect(icons.some((icon) => icon.attributes("data-icon") === "check")).toBe(
+      false
+    );
+  });
+
+  it("uses buttons for completed steps instead of tabindex on icon divs", async () => {
+    const wrapper = mountStepper("3");
+
+    const buttons = wrapper.findAll("button.m-form-step__button");
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].text()).toContain("Zurück zu Schritt: Order");
+    expect(buttons[0].find("div.m-form-step__icon").exists()).toBe(true);
+
+    const decorativeIcons = wrapper
+      .findAll("div.m-form-step__icon")
+      .filter((icon) => !icon.element.closest("button"));
+    expect(decorativeIcons).toHaveLength(2);
+    decorativeIcons.forEach((icon) => {
+      expect(icon.attributes("tabindex")).toBeUndefined();
+      expect(icon.attributes("aria-label")).toBeUndefined();
+      expect(icon.attributes("aria-current")).toBeUndefined();
+      expect(icon.attributes("aria-labelledby")).toBeUndefined();
+    });
+
+    await buttons[0].trigger("click");
+    expect(wrapper.emitted("changeStep")?.[0]).toEqual(["1"]);
+  });
+
+  it("does not render clickable previous steps when disabled", () => {
+    const wrapper = mountStepper("3", true);
+
+    expect(wrapper.findAll("button.m-form-step__button")).toHaveLength(0);
+    expect(wrapper.findAll("div.m-form-step__icon.disabled")).toHaveLength(2);
+  });
+});

--- a/src/components/Stepper/MucStepper.vue
+++ b/src/components/Stepper/MucStepper.vue
@@ -3,25 +3,28 @@
     <div class="container">
       <div class="m-component__grid">
         <div class="m-component__column">
-          <ol
-            class="m-form-steps"
-            role="list"
-            aria-label="Formularfortschritt"
-          >
-            <template
-              v-for="(item, index) in stepItems"
+          <h2 class="m-form-steps__heading visually-hidden">
+            <span class="m-form-steps__heading-counter">
+              Schritt
+              <span class="m-form-steps__current-step">{{
+                activePosition
+              }}</span>
+              <span class="m-form-steps__total-steps"
+                >von {{ stepItems.length }}:</span
+              >
+            </span>
+            <span class="m-form-steps__heading-text">{{ activeLabel }}</span>
+          </h2>
+          <ol class="m-form-steps">
+            <muc-stepper-item
+              v-for="item in stepItems"
               :key="item.id"
-            >
-              <muc-stepper-item
-                :item="item"
-                :is-active="isActive(item.id)"
-                :is-done="isDone(item.id)"
-                :disabled="disabled(item.id)"
-                :position="index + 1"
-                :total="stepItems.length"
-                @click="handleChange"
-              />
-            </template>
+              :item="item"
+              :is-active="isActive(item.id)"
+              :is-done="isDone(item.id)"
+              :disabled="disabled(item.id)"
+              @click="handleChange"
+            />
           </ol>
         </div>
       </div>
@@ -30,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 
 import MucStepperItem from "./MucStepperItem.vue";
 import { StepperItem } from "./MucStepperTypes";
@@ -84,6 +87,14 @@ const getIndexOfItem = (id: string) => {
  * Index of activ item
  */
 const indexOfActivItem = ref<number>(getIndexOfItem(activeItem));
+
+const activePosition = computed(() =>
+  indexOfActivItem.value >= 0 ? indexOfActivItem.value + 1 : 1
+);
+
+const activeLabel = computed(
+  () => stepItems.find((item) => item.id === activeItem)?.label ?? ""
+);
 
 /**
  * Checks if an item is the activ item

--- a/src/components/Stepper/MucStepper.vue
+++ b/src/components/Stepper/MucStepper.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 
 import MucStepperItem from "./MucStepperItem.vue";
 import { StepperItem } from "./MucStepperTypes";
@@ -67,13 +67,6 @@ const emit = defineEmits<{
   changeStep: [id: string];
 }>();
 
-watch(
-  () => activeItem,
-  () => {
-    indexOfActivItem.value = getIndexOfItem(activeItem);
-  }
-);
-
 /**
  * Returns the index of an item in the array
  * @param id id of the item
@@ -84,9 +77,9 @@ const getIndexOfItem = (id: string) => {
 };
 
 /**
- * Index of activ item
+ * Index of active item (recomputed when stepItems or activeItem change)
  */
-const indexOfActivItem = ref<number>(getIndexOfItem(activeItem));
+const indexOfActivItem = computed(() => getIndexOfItem(activeItem));
 
 const activePosition = computed(() =>
   indexOfActivItem.value >= 0 ? indexOfActivItem.value + 1 : 1

--- a/src/components/Stepper/MucStepperItem.vue
+++ b/src/components/Stepper/MucStepperItem.vue
@@ -68,8 +68,7 @@ const emit = defineEmits<{
 }>();
 
 /**
- * Completed steps stay navigable via a real button (Patternlab: no tabindex on div).
- * Done steps keep their original step icon instead of a check icon.
+ * Checks if step is clickable
  */
 const isClickable = computed(() => isDone && !disabled && !isActive);
 

--- a/src/components/Stepper/MucStepperItem.vue
+++ b/src/components/Stepper/MucStepperItem.vue
@@ -4,19 +4,15 @@
     :class="{ 'm-form-step--current': isActive }"
     :aria-current="isActive ? 'step' : undefined"
   >
-    <!--
-      Keep Patternlab's div.m-form-step__icon for circle styling.
-      Use a display:contents button wrapper for keyboard-accessible navigation.
-    -->
     <button
       v-if="isClickable"
       type="button"
       class="m-form-step__button"
       @click="handleClick"
     >
-      <div class="m-form-step__icon">
+      <span class="m-form-step__icon">
         <muc-icon :icon="item.icon" />
-      </div>
+      </span>
       <span class="visually-hidden">Zurück zu Schritt: {{ item.label }}</span>
     </button>
     <div
@@ -85,7 +81,6 @@ const handleClick = () => {
 </script>
 
 <style scoped>
-/* Lets Patternlab layout treat .m-form-step__icon as a direct child of .m-form-step */
 .m-form-step__button {
   appearance: none;
   margin: 0;
@@ -95,7 +90,17 @@ const handleClick = () => {
   font: inherit;
   color: inherit;
   cursor: pointer;
-  display: contents;
+  display: flex;
+  justify-content: center;
+}
+
+.m-form-step__button:focus {
+  outline: none;
+}
+
+.m-form-step__button:focus-visible .m-form-step__icon {
+  outline: 2px solid #005a9f;
+  outline-offset: 2px;
 }
 
 .disabled {

--- a/src/components/Stepper/MucStepperItem.vue
+++ b/src/components/Stepper/MucStepperItem.vue
@@ -1,59 +1,37 @@
 <template>
   <li
     class="m-form-step"
-    :class="{
-      'm-form-step--current': isActive,
-      'show-cursor': isDone && !disabled && !isActive,
-    }"
-    @click="handleClick"
+    :class="{ 'm-form-step--current': isActive }"
+    :aria-current="isActive ? 'step' : undefined"
   >
+    <!--
+      Keep Patternlab's div.m-form-step__icon for circle styling.
+      Use a display:contents button wrapper for keyboard-accessible navigation.
+    -->
+    <button
+      v-if="isClickable"
+      type="button"
+      class="m-form-step__button"
+      @click="handleClick"
+    >
+      <div class="m-form-step__icon">
+        <muc-icon :icon="item.icon" />
+      </div>
+      <span class="visually-hidden">Zurück zu Schritt: {{ item.label }}</span>
+    </button>
     <div
+      v-else
       class="m-form-step__icon"
       :class="{ disabled: disabled }"
-      :tabindex="getTabindex"
-      :aria-labelledby="ariaLabelledby"
-      :aria-label="getAriaLabel"
-      :aria-setsize="total"
-      :aria-posinset="position"
-      :aria-current="isActive ? 'step' : false"
     >
-      <muc-icon :icon="getIcon" />
+      <muc-icon :icon="item.icon" />
     </div>
     <div
       class="m-form-step__title"
       :class="{ disabled: disabled }"
     >
-      <span
-        :id="labelId"
-        aria-disabled="true"
-      >
-        {{ item.label }}</span
-      >
-
-      <span
-        class="visually-hidden"
-        :id="prefixId"
-      >
-        Schritt {{ position }} von {{ total }}:
-      </span>
-
-      <span
-        v-if="isDone"
-        class="visually-hidden"
-        :id="statusId"
-      >
-        – erledigt
-      </span>
+      <span>{{ item.label }}</span>
     </div>
-    <span
-      v-if="isActive"
-      class="visually-hidden"
-      role="status"
-      aria-live="polite"
-      aria-atomic="true"
-      :aria-labelledby="ariaLabelledby"
-    >
-    </span>
   </li>
 </template>
 
@@ -63,7 +41,7 @@ import { computed } from "vue";
 import { MucIcon } from "../Icon";
 import { StepperItem } from "./MucStepperTypes";
 
-const { item, isActive, isDone, disabled, position, total } = defineProps<{
+const { item, isActive, isDone, disabled } = defineProps<{
   /**
    * Individual item to display inside the MucStepper component
    */
@@ -83,16 +61,6 @@ const { item, isActive, isDone, disabled, position, total } = defineProps<{
    * Disabled stepper
    */
   disabled: boolean;
-
-  /**
-   * position of the item in the step sequence
-   */
-  position: number;
-
-  /**
-   * total number of steps
-   */
-  total: number;
 }>();
 
 const emit = defineEmits<{
@@ -104,52 +72,30 @@ const emit = defineEmits<{
 }>();
 
 /**
- * Computed property set icon of step
+ * Completed steps stay navigable via a real button (Patternlab: no tabindex on div).
+ * Done steps keep their original step icon instead of a check icon.
  */
-const getIcon = computed(() => (isDone ? "check" : item.icon));
-
-/**
- * Computed property set tabindex
- */
-const getTabindex = computed(() =>
-  isActive || (isDone && !disabled) ? 0 : -1
-);
-
-/**
- * Computed property set aria-label
- */
-const getAriaLabel = computed(() =>
-  isActive
-    ? "Aktueller Schritt: " + item.label
-    : "Zurück zu Schritt: " + item.label
-);
-
-/**
- * Stable element IDs used to compose the accessible name via aria-labelledby
- */
-const labelId = computed(() => `m-step-label-${item.id}`);
-const prefixId = computed(() => `m-step-prefix-${item.id}`);
-const statusId = computed(() => `m-step-status-${item.id}`);
-
-/**
- * Compose the accessible name in order: prefix -> visible label -> optional status
- */
-const ariaLabelledby = computed(() => {
-  const ids = [prefixId.value, labelId.value];
-  if (isDone) ids.push(statusId.value);
-  return ids.join(" ");
-});
+const isClickable = computed(() => isDone && !disabled && !isActive);
 
 const handleClick = () => {
-  if (isDone && !disabled) {
+  if (isClickable.value) {
     emit("click", item.id);
   }
 };
 </script>
 
 <style scoped>
-.show-cursor {
+/* Lets Patternlab layout treat .m-form-step__icon as a direct child of .m-form-step */
+.m-form-step__button {
+  appearance: none;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  color: inherit;
   cursor: pointer;
+  display: contents;
 }
 
 .disabled {


### PR DESCRIPTION
## Summary
- Align MucStepper DOM/ARIA with Patternlab `components-form-steps` (heading, list attrs, `aria-current` on `li`, no tabindex/ARIA on icon divs)
- Keep original step icons for completed steps (no check icon)
- Use a real button (with `div.m-form-step__icon` inside) for going back to completed steps

Fixes stuff from Pfennigparade. https://patternlab.muenchen.space/?p=components-form-steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessible heading that identifies the current step and total progress.
  * Completed steps are now navigable using standard buttons.
  * Improved stepper behavior when previous steps are disabled.

* **Bug Fixes**
  * Improved accessibility semantics for step navigation and decorative icons.
  * Ensured only the current step receives the current-step indicator.
  * Corrected back-navigation event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->