### PR TITLE
:sparkles: MucBanner emergency-light, leftBorder and header slot

### DIFF
--- a/src/components/Banner/MucBanner.stories.ts
+++ b/src/components/Banner/MucBanner.stories.ts
@@ -11,8 +11,6 @@ export default {
       description: {
         component: `A banner-component used for single-line informations. Available in multiple types.
 
-Supports an additional light danger style (\`danger\`).
-
 [🔗 Patternlab-Docs](https://patternlab.muenchen.space/?p=viewall-elements-banner)
 `,
       },

--- a/src/components/Banner/MucBanner.stories.ts
+++ b/src/components/Banner/MucBanner.stories.ts
@@ -9,9 +9,9 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: `A banner-component used for informations. Available in multiple types.
+        component: `A banner-component used for single-line informations. Available in multiple types.
 
-Supports an optional \`header\` slot, a light emergency style (\`emergency-light\`), and an optional left accent border (\`leftBorder\`).
+Supports an additional light danger style (\`danger\`).
 
 [🔗 Patternlab-Docs](https://patternlab.muenchen.space/?p=viewall-elements-banner)
 `,
@@ -52,36 +52,11 @@ export const Emergency = {
   },
 };
 
-export const EmergencyLight = {
+export const Danger = {
   args: {
+    default: "Hi, I'm a Danger-Banner!",
     variant: "content",
-    type: "emergency-light",
-    leftBorder: true,
-  },
-  render: (args: Record<string, unknown>) => ({
-    components: { MucBanner },
-    setup() {
-      return { args };
-    },
-    template: `
-      <muc-banner
-        :variant="args.variant"
-        :type="args.type"
-        :left-border="args.leftBorder"
-      >
-        <template #header>Hi, I'm an Emergency-Light-Banner!</template>
-        Hi, I'm the content of an Emergency-Light-Banner!
-      </muc-banner>
-    `,
-  }),
-};
-
-export const LeftBorder = {
-  args: {
-    default: "Hi, I'm a Warning-Banner with a left border!",
-    variant: "content",
-    type: "warning",
-    leftBorder: true,
+    type: "danger",
   },
 };
 

--- a/src/components/Banner/MucBanner.stories.ts
+++ b/src/components/Banner/MucBanner.stories.ts
@@ -9,7 +9,9 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: `A banner-component used for single-line informations. Available in multiple types.
+        component: `A banner-component used for informations. Available in multiple types.
+
+Supports an optional \`header\` slot, a light emergency style (\`emergency-light\`), and an optional left accent border (\`leftBorder\`).
 
 [🔗 Patternlab-Docs](https://patternlab.muenchen.space/?p=viewall-elements-banner)
 `,
@@ -47,6 +49,39 @@ export const Emergency = {
     default: "Hi, I'm an Emergency-Banner!",
     variant: "content",
     type: "emergency",
+  },
+};
+
+export const EmergencyLight = {
+  args: {
+    variant: "content",
+    type: "emergency-light",
+    leftBorder: true,
+  },
+  render: (args: Record<string, unknown>) => ({
+    components: { MucBanner },
+    setup() {
+      return { args };
+    },
+    template: `
+      <muc-banner
+        :variant="args.variant"
+        :type="args.type"
+        :left-border="args.leftBorder"
+      >
+        <template #header>Hi, I'm an Emergency-Light-Banner!</template>
+        Hi, I'm the content of an Emergency-Light-Banner!
+      </muc-banner>
+    `,
+  }),
+};
+
+export const LeftBorder = {
+  args: {
+    default: "Hi, I'm a Warning-Banner with a left border!",
+    variant: "content",
+    type: "warning",
+    leftBorder: true,
   },
 };
 

--- a/src/components/Banner/MucBanner.test.ts
+++ b/src/components/Banner/MucBanner.test.ts
@@ -64,52 +64,18 @@ describe("MucBanner.vue", () => {
     expect(mucBanner.text()).toContain("This is an emergency message");
   });
 
-  it("renders with emergency-light type", () => {
+  it("renders with danger type", () => {
     const wrapper = mount(MucBanner, {
-      props: { variant: "content", type: "emergency-light" },
+      props: { variant: "content", type: "danger" },
       slots: {
-        default: "This is a light emergency message",
+        default: "This is a danger message",
       },
     });
 
     const mucBanner = wrapper.find(".m-banner");
-    expect(mucBanner.classes()).toContain("m-banner--emergency-light");
+    expect(mucBanner.classes()).toContain("m-banner--danger");
     expect(mucBanner.attributes("role")).toBe("alert");
-    expect(mucBanner.attributes("aria-label")).toBe("Emergency");
-    expect(mucBanner.text()).toContain("This is a light emergency message");
-  });
-
-  it("renders left border when leftBorder is true", () => {
-    const wrapper = mount(MucBanner, {
-      props: {
-        variant: "content",
-        type: "emergency-light",
-        leftBorder: true,
-      },
-      slots: {
-        default: "Bordered message",
-      },
-    });
-
-    expect(wrapper.find(".m-banner").classes()).toContain(
-      "m-banner--left-border"
-    );
-  });
-
-  it("renders header and content slots", () => {
-    const wrapper = mount(MucBanner, {
-      props: { variant: "content", type: "emergency-light", leftBorder: true },
-      slots: {
-        header: "Fehler bei der Anmeldung",
-        default: "Ihre Anmeldung ist leider fehlgeschlagen.",
-      },
-    });
-
-    expect(wrapper.find(".m-banner__headline").text()).toBe(
-      "Fehler bei der Anmeldung"
-    );
-    expect(wrapper.find(".m-banner__content").text()).toBe(
-      "Ihre Anmeldung ist leider fehlgeschlagen."
-    );
+    expect(mucBanner.attributes("aria-label")).toBe("Danger");
+    expect(mucBanner.text()).toContain("This is a danger message");
   });
 });

--- a/src/components/Banner/MucBanner.test.ts
+++ b/src/components/Banner/MucBanner.test.ts
@@ -63,4 +63,53 @@ describe("MucBanner.vue", () => {
     expect(mucBanner.attributes("aria-label")).toBe("Emergency");
     expect(mucBanner.text()).toContain("This is an emergency message");
   });
+
+  it("renders with emergency-light type", () => {
+    const wrapper = mount(MucBanner, {
+      props: { variant: "content", type: "emergency-light" },
+      slots: {
+        default: "This is a light emergency message",
+      },
+    });
+
+    const mucBanner = wrapper.find(".m-banner");
+    expect(mucBanner.classes()).toContain("m-banner--emergency-light");
+    expect(mucBanner.attributes("role")).toBe("alert");
+    expect(mucBanner.attributes("aria-label")).toBe("Emergency");
+    expect(mucBanner.text()).toContain("This is a light emergency message");
+  });
+
+  it("renders left border when leftBorder is true", () => {
+    const wrapper = mount(MucBanner, {
+      props: {
+        variant: "content",
+        type: "emergency-light",
+        leftBorder: true,
+      },
+      slots: {
+        default: "Bordered message",
+      },
+    });
+
+    expect(wrapper.find(".m-banner").classes()).toContain(
+      "m-banner--left-border"
+    );
+  });
+
+  it("renders header and content slots", () => {
+    const wrapper = mount(MucBanner, {
+      props: { variant: "content", type: "emergency-light", leftBorder: true },
+      slots: {
+        header: "Fehler bei der Anmeldung",
+        default: "Ihre Anmeldung ist leider fehlgeschlagen.",
+      },
+    });
+
+    expect(wrapper.find(".m-banner__headline").text()).toBe(
+      "Fehler bei der Anmeldung"
+    );
+    expect(wrapper.find(".m-banner__content").text()).toBe(
+      "Ihre Anmeldung ist leider fehlgeschlagen."
+    );
+  });
 });

--- a/src/components/Banner/MucBanner.vue
+++ b/src/components/Banner/MucBanner.vue
@@ -1,17 +1,15 @@
 <script setup lang="ts">
-import { computed, useSlots } from "vue";
+import { computed } from "vue";
 
 import { MucIcon } from "../Icon";
 
-type bannerType =
-  "info" | "success" | "warning" | "emergency" | "emergency-light";
+type bannerType = "info" | "success" | "warning" | "emergency" | "danger";
 type bannerVariant = "content" | "header";
 
 const {
   type = "info",
   variant,
   noIcon = false,
-  leftBorder = false,
 } = defineProps<{
   /**
    * Changes the style of the banner. Available types are `content` and `header`. `content` is used in the content area. `header` is used directly below the header and has more padding.
@@ -19,31 +17,19 @@ const {
   variant: bannerVariant;
 
   /**
-   * Changes the style of the banner. Available types are `info`, `success`, `warning`, `emergency` and `emergency-light`.
+   * Changes the style of the banner. Available types are `info`, `success`, `warning`, `emergency` and `danger`.
    */
   type?: bannerType;
 
   noIcon?: boolean;
-
-  /**
-   * Shows a coloured accent bar on the left side of the banner.
-   */
-  leftBorder?: boolean;
 }>();
 
 defineSlots<{
-  /**
-   * Optional heading shown above the banner text.
-   */
-  header(): unknown;
   /**
    * Text-content of the banner.
    */
   default(): unknown;
 }>();
-
-const slots = useSlots();
-const hasHeader = computed(() => Boolean(slots.header));
 
 const typeClass = computed(() => {
   switch (type) {
@@ -55,8 +41,8 @@ const typeClass = computed(() => {
       return "m-banner--warning";
     case "emergency":
       return "m-banner--emergency";
-    case "emergency-light":
-      return "m-banner--emergency-light";
+    case "danger":
+      return "m-banner--danger";
     default:
       return "m-banner--info";
   }
@@ -70,7 +56,7 @@ const typeRole = computed(() => {
       return "dialog";
     case "warning":
     case "emergency":
-    case "emergency-light":
+    case "danger":
       return "alert";
     default:
       return "dialog";
@@ -86,8 +72,9 @@ const typeAriaLabel = computed(() => {
     case "warning":
       return "Warnung";
     case "emergency":
-    case "emergency-light":
       return "Emergency";
+    case "danger":
+      return "Danger";
     default:
       return "Information";
   }
@@ -99,24 +86,19 @@ const typeIcon = computed(() => {
       return "check";
     case "warning":
     case "emergency":
-    case "emergency-light":
+    case "danger":
       return "warning";
     case "info":
     default:
       return "information";
   }
 });
-
-const rootClass = computed(() => [
-  typeClass.value,
-  { "m-banner--left-border": leftBorder },
-]);
 </script>
 
 <template>
   <div
     class="m-banner"
-    :class="rootClass"
+    :class="typeClass"
     :role="typeRole"
     :aria-label="typeAriaLabel"
   >
@@ -125,18 +107,7 @@ const rootClass = computed(() => [
         v-if="!noIcon"
         :icon="typeIcon"
       />
-      <div
-        v-if="hasHeader"
-        class="m-banner__body"
-      >
-        <p class="m-banner__headline">
-          <slot name="header" />
-        </p>
-        <p class="m-banner__content">
-          <slot />
-        </p>
-      </div>
-      <p v-else>
+      <p>
         <slot />
       </p>
     </template>
@@ -146,18 +117,7 @@ const rootClass = computed(() => [
           v-if="!noIcon"
           :icon="typeIcon"
         />
-        <div
-          v-if="hasHeader"
-          class="m-banner__body"
-        >
-          <p class="m-banner__headline">
-            <slot name="header" />
-          </p>
-          <p class="m-banner__content">
-            <slot />
-          </p>
-        </div>
-        <p v-else>
+        <p>
           <slot />
         </p>
       </div>
@@ -167,55 +127,9 @@ const rootClass = computed(() => [
 
 <style>
 /* Not yet part of MDE patternlab – provided by muc-patternlab-vue. */
-.m-banner--emergency-light {
+.m-banner--danger {
   background-color: var(--mde-color-status-error-x-light, #f8f2f2);
   border-bottom: 1px solid var(--mde-color-status-error-light, #c79a9b);
   color: var(--mde-color-neutral-grey, #3a5368);
-}
-
-.m-banner--left-border {
-  border-left-width: 4px;
-  border-left-style: solid;
-}
-
-.m-banner--info.m-banner--left-border {
-  border-left-color: var(--mde-color-brand-mde-blue, #005a9f);
-  border-bottom: none;
-}
-
-.m-banner--success.m-banner--left-border {
-  border-left-color: var(--mde-color-status-success, #3a7f53);
-  border-bottom: none;
-}
-
-.m-banner--warning.m-banner--left-border {
-  border-left-color: var(--mde-color-status-warning, #fcaa67);
-  border-bottom: none;
-}
-
-.m-banner--emergency.m-banner--left-border {
-  border-left-color: #7a282b;
-  border-bottom: none;
-}
-
-.m-banner--emergency-light.m-banner--left-border {
-  border-left-color: var(--mde-color-status-error, #984447);
-  border-bottom: none;
-}
-
-.m-banner__body {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  min-width: 0;
-}
-
-.m-banner__headline {
-  font-weight: 700;
-  margin: 0;
-}
-
-.m-banner__content {
-  margin: 0;
 }
 </style>

--- a/src/components/Banner/MucBanner.vue
+++ b/src/components/Banner/MucBanner.vue
@@ -126,7 +126,6 @@ const typeIcon = computed(() => {
 </template>
 
 <style>
-/* Not yet part of MDE patternlab – provided by muc-patternlab-vue. */
 .m-banner--danger {
   background-color: var(--mde-color-status-error-x-light, #f8f2f2);
   border-bottom: 1px solid var(--mde-color-status-error-light, #c79a9b);

--- a/src/components/Banner/MucBanner.vue
+++ b/src/components/Banner/MucBanner.vue
@@ -1,15 +1,21 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useSlots } from "vue";
 
 import { MucIcon } from "../Icon";
 
-type bannerType = "info" | "success" | "warning" | "emergency";
+type bannerType =
+  | "info"
+  | "success"
+  | "warning"
+  | "emergency"
+  | "emergency-light";
 type bannerVariant = "content" | "header";
 
 const {
   type = "info",
   variant,
   noIcon = false,
+  leftBorder = false,
 } = defineProps<{
   /**
    * Changes the style of the banner. Available types are `content` and `header`. `content` is used in the content area. `header` is used directly below the header and has more padding.
@@ -17,19 +23,31 @@ const {
   variant: bannerVariant;
 
   /**
-   * Changes the style of the banner. Available types are `info`, `success`, `warning` and `emergency`.
+   * Changes the style of the banner. Available types are `info`, `success`, `warning`, `emergency` and `emergency-light`.
    */
   type?: bannerType;
 
   noIcon?: boolean;
+
+  /**
+   * Shows a coloured accent bar on the left side of the banner.
+   */
+  leftBorder?: boolean;
 }>();
 
 defineSlots<{
+  /**
+   * Optional heading shown above the banner text.
+   */
+  header(): unknown;
   /**
    * Text-content of the banner.
    */
   default(): unknown;
 }>();
+
+const slots = useSlots();
+const hasHeader = computed(() => Boolean(slots.header));
 
 const typeClass = computed(() => {
   switch (type) {
@@ -41,6 +59,8 @@ const typeClass = computed(() => {
       return "m-banner--warning";
     case "emergency":
       return "m-banner--emergency";
+    case "emergency-light":
+      return "m-banner--emergency-light";
     default:
       return "m-banner--info";
   }
@@ -53,8 +73,8 @@ const typeRole = computed(() => {
     case "success":
       return "dialog";
     case "warning":
-      return "alert";
     case "emergency":
+    case "emergency-light":
       return "alert";
     default:
       return "dialog";
@@ -70,6 +90,7 @@ const typeAriaLabel = computed(() => {
     case "warning":
       return "Warnung";
     case "emergency":
+    case "emergency-light":
       return "Emergency";
     default:
       return "Information";
@@ -82,18 +103,24 @@ const typeIcon = computed(() => {
       return "check";
     case "warning":
     case "emergency":
+    case "emergency-light":
       return "warning";
     case "info":
     default:
       return "information";
   }
 });
+
+const rootClass = computed(() => [
+  typeClass.value,
+  { "m-banner--left-border": leftBorder },
+]);
 </script>
 
 <template>
   <div
     class="m-banner"
-    :class="typeClass"
+    :class="rootClass"
     :role="typeRole"
     :aria-label="typeAriaLabel"
   >
@@ -102,7 +129,18 @@ const typeIcon = computed(() => {
         v-if="!noIcon"
         :icon="typeIcon"
       />
-      <p>
+      <div
+        v-if="hasHeader"
+        class="m-banner__body"
+      >
+        <p class="m-banner__headline">
+          <slot name="header" />
+        </p>
+        <p class="m-banner__content">
+          <slot />
+        </p>
+      </div>
+      <p v-else>
         <slot />
       </p>
     </template>
@@ -112,10 +150,76 @@ const typeIcon = computed(() => {
           v-if="!noIcon"
           :icon="typeIcon"
         />
-        <p>
+        <div
+          v-if="hasHeader"
+          class="m-banner__body"
+        >
+          <p class="m-banner__headline">
+            <slot name="header" />
+          </p>
+          <p class="m-banner__content">
+            <slot />
+          </p>
+        </div>
+        <p v-else>
           <slot />
         </p>
       </div>
     </template>
   </div>
 </template>
+
+<style>
+/* Not yet part of MDE patternlab – provided by muc-patternlab-vue. */
+.m-banner--emergency-light {
+  background-color: var(--mde-color-status-error-x-light, #f8f2f2);
+  border-bottom: 1px solid var(--mde-color-status-error-light, #c79a9b);
+  color: var(--mde-color-neutral-grey, #3a5368);
+}
+
+.m-banner--left-border {
+  border-left-width: 4px;
+  border-left-style: solid;
+}
+
+.m-banner--info.m-banner--left-border {
+  border-left-color: var(--mde-color-brand-mde-blue, #005a9f);
+  border-bottom: none;
+}
+
+.m-banner--success.m-banner--left-border {
+  border-left-color: var(--mde-color-status-success, #3a7f53);
+  border-bottom: none;
+}
+
+.m-banner--warning.m-banner--left-border {
+  border-left-color: var(--mde-color-status-warning, #fcaa67);
+  border-bottom: none;
+}
+
+.m-banner--emergency.m-banner--left-border {
+  border-left-color: #7a282b;
+  border-bottom: none;
+}
+
+.m-banner--emergency-light.m-banner--left-border {
+  border-left-color: var(--mde-color-status-error, #984447);
+  border-bottom: none;
+}
+
+.m-banner__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.m-banner__headline {
+  font-weight: 700;
+  margin: 0;
+}
+
+.m-banner__content {
+  margin: 0;
+}
+</style>

--- a/src/components/Banner/MucBanner.vue
+++ b/src/components/Banner/MucBanner.vue
@@ -4,11 +4,7 @@ import { computed, useSlots } from "vue";
 import { MucIcon } from "../Icon";
 
 type bannerType =
-  | "info"
-  | "success"
-  | "warning"
-  | "emergency"
-  | "emergency-light";
+  "info" | "success" | "warning" | "emergency" | "emergency-light";
 type bannerVariant = "content" | "header";
 
 const {


### PR DESCRIPTION
## Summary
- Add `type="emergency-light"` (light emergency styling)
- Add `leftBorder` prop for a coloured left accent bar
- Add optional `#header` slot for banner title + body

Prep work for ZMSKVR-1529.